### PR TITLE
Cherry-pick lodash methods for smaller bundles

### DIFF
--- a/sources/core/reduxBatch.js
+++ b/sources/core/reduxBatch.js
@@ -1,4 +1,5 @@
-import { isArray, isFunction } from 'lodash';
+import isArray from 'lodash/isArray';
+import isFunction from 'lodash/isFunction';
 
 export function reduxBatch(next) {
 


### PR DESCRIPTION
The original version pulls extra ~500Kb to webpack build even though only 2 simple functions are needed.