### PR TITLE
Export BatchEnhancer to allow custom action types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,9 @@
 declare module "@manaflair/redux-batch" {
-  import { AnyAction, StoreEnhancer } from "redux";
+  import { Action, AnyAction, StoreEnhancer } from "redux";
 
-  export const reduxBatch: StoreEnhancer<{
-    dispatch: (actions: AnyAction[]) => AnyAction[],
+  export type BatchEnhancer<A extends Action = AnyAction> = StoreEnhancer<{
+    dispatch: (actions: A[]) => A[];
   }>;
+
+  export const reduxBatch: BatchEnhancer;
 }


### PR DESCRIPTION
This extends the TypeScript definitions by exporting the `BatchEnhancer<A extends Action = AnyAction>` type. It can be used to specify the type of actions supported by your store. For example, if all your actions have a `string` payload, you might define a `MyAction` with like this:
```ts
import { Action } from "redux";
type MyAction = Action<string> & { payload: string };
```

Without this PR, the following code produces these typings for `store.dispatch()`:
- `(action: MyAction): MyAction` (correct)
- `(actions: AnyAction[]): AnyAction[]` (incorrect)

```ts
const store = createStore(
  combineReducers<State, MyAction>(reducers),
  initialState,
  reduxBatch
);
```

With this PR, you can use the `BatchEnhancer` type to manually specify your action type, yielding to the correct typings for `store.dispatch()`:
- `(action: MyAction): MyAction` (correct)
- `(actions: MyAction[]): MyAction[]` (incorrect)

```ts
const store = createStore(
  combineReducers<State, MyAction>(reducers),
  initialState,
  reduxBatch as BatchEnhancer<Action>
);
```