### PR TITLE
Fix for graceful error propagation

### DIFF
--- a/sources/core/reduxBatch.js
+++ b/sources/core/reduxBatch.js
@@ -70,7 +70,16 @@ export function reduxBatch(next) {
                 inDispatch = true;
             }
 
-            let result = dispatchRecurse(action);
+            let hasError = false;
+            let error = undefined;
+            let result = undefined;
+            try {
+                result = dispatchRecurse(action);
+            } catch (e) {
+                hasError = true;
+                error = e;
+            }
+
             let requiresNotification = receivedNotification && !reentrant;
 
             if (!reentrant) {
@@ -81,8 +90,10 @@ export function reduxBatch(next) {
             if (requiresNotification)
                 notifyListeners();
 
+            if (hasError) {
+                throw error;
+            }
             return result;
-
         }
 
         store.subscribe(() => {


### PR DESCRIPTION
Hello!

Currently, if an error is thrown during dispatch - it breaks future store notifications. This PR should fix that, to match the default dispatch behaviour.

Steps to reproduce:
 1. Place intentional error in reducer
 2. Dispatch action that crashes in the reducer
 3. Dispatch other actions and you will see that listeners do not get notified of state changes. Compared with "plain" redux where listeners updated
 
Let me know if the issue & this solution is clear to you